### PR TITLE
remove android preview from IDX

### DIFF
--- a/.idx/dev.nix
+++ b/.idx/dev.nix
@@ -2,7 +2,6 @@
   channel = "stable-23.11";
   packages = [
     pkgs.nodePackages.firebase-tools
-    pkgs.jdk17
     pkgs.unzip
   ];
   idx.extensions = [
@@ -21,18 +20,6 @@
           "0.0.0.0"
           "--web-port"
           "$PORT"
-        ];
-        manager = "flutter";
-      };
-      android = {
-        command = [
-          "flutter"
-          "run"
-          "--machine"
-          "-d"
-          "android"
-          "-d"
-          "emulator-5554"
         ];
         manager = "flutter";
       };


### PR DESCRIPTION
Android has not been set up for this project, but once we launch it in Project IDX the Android preview is shown.

This PR should:
- remove the Android preview from the default IDX workspace.
- remove the dependency on JDK 17 since the project doesn't use Java.